### PR TITLE
Fix stack traces for non_fungible_token_asset type

### DIFF
--- a/backend/src/helpers.ts
+++ b/backend/src/helpers.ts
@@ -186,7 +186,7 @@ export const getEvents = async () => {
     shouldDeleteEvents === true ? rawEvents : dbEvents.concat(rawEvents);
 
   for (const entry of parsedEvents) {
-    if (entry?.contract_log?.value?.repr?.includes(POOL_OPERATOR)) {
+    if (entry?.contract_log?.contract_id === 'SP000000000000000000002Q6VF78.pox-4' && entry?.contract_log?.value?.repr?.includes(POOL_OPERATOR)) {
       const result = parseStringToJSON(entry.contract_log.value.repr);
       if (result.name == 'delegate-stx') {
         events.push({

--- a/backend/src/helpers.ts
+++ b/backend/src/helpers.ts
@@ -186,7 +186,7 @@ export const getEvents = async () => {
     shouldDeleteEvents === true ? rawEvents : dbEvents.concat(rawEvents);
 
   for (const entry of parsedEvents) {
-    if (entry.contract_log.value.repr.includes(POOL_OPERATOR)) {
+    if (entry?.contract_log?.value?.repr?.includes(POOL_OPERATOR)) {
       const result = parseStringToJSON(entry.contract_log.value.repr);
       if (result.name == 'delegate-stx') {
         events.push({

--- a/backend/src/save-data.ts
+++ b/backend/src/save-data.ts
@@ -100,10 +100,10 @@ export const saveEvents = async (events: any) => {
       event_index,
       event_type,
       tx_id,
-      contract_log.contract_id,
-      contract_log.topic,
-      contract_log.value.hex,
-      contract_log.value.repr,
+      contract_log?.contract_id || null,
+      contract_log?.topic || null,
+      contract_log?.value.hex || null,
+      contract_log?.value.repr || null,
     ]);
   }
 };


### PR DESCRIPTION
While running this on mainnet, the tool stack traces:
```
Error: TypeError: Cannot read properties of undefined (reading 'value')
    at getEvents (/src/stacks/stacker-flow-automation/backend/src/helpers.ts:207:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async main (/src/stacks/stacker-flow-automation/backend/src/index.ts:53:24)
```

I did some troubleshooting, and I believe it's erroring on these type of events:
```
{
  event_index: 133,
  event_type: 'non_fungible_token_asset',
  tx_id: '0xdaf1b188dd4b9bf766598acc8dfad9c273a48aa33950eb844409e7dddfe7aaf5',
}
```

I believe this fixes that error and the script now will run through both the initial import (on a first-time run), and any subsequent runs.